### PR TITLE
Remove map scroll zoom, add container to video

### DIFF
--- a/public/scripts/application.js
+++ b/public/scripts/application.js
@@ -2,7 +2,7 @@
 *
 * application.js
 *
-* This stores our core JavaScript. 
+* This stores our core JavaScript.
 *
 **/
 
@@ -33,84 +33,84 @@
 // =====
 
 $(document).ready(function(){
-  
+
   $('#js-menu-toggle').click(function(e){
     e.preventDefault();
     $('body').toggleClass('js-menu-open');
   });
-  
+
   // =====
   // LEAFLET
   // =====
-  
+
   //console.log($('#map').length);
-  
+
   //only run map code if the map container exists.
   if($('#map').length > 0) {
-    
+
     var greenIcon = L.icon({
       iconUrl: 'assets/images/oac-pin.svg',
-  
+
       iconSize:     [20, 24], // size of the icon
       iconAnchor:   [10, 12], // point of the icon which will correspond to marker's location
       popupAnchor:  [0,-12] // point from which the popup should open relative to the iconAnchor
     });
-    
-    var map = L.map('map').setView([14.54637, 8.97583], 2);
+
+    var map = L.map('map', { scrollWheelZoom: false }).setView([14.54637, 8.97583], 2);
     var layer = new L.StamenTileLayer("toner-lite");
-        
+
     map.addLayer(layer);
-  
+
     /*map.on('click', function(e) {
         alert(e.latlng);
     });*/
-  
+
     $('.map-data').each(function() {
-    
+
       var url = $(this).find('a').attr('href');
       var chapter = '<a href="' + url + '">' + $(this).find('.chapter-name').text() + '</a>';
       var coords = $(this).find('.coordinates').text();
-      
+
       if(coords != '') {
-        
+
         var lat = parseFloat(coords.split(',')[0]);
         var lng = parseFloat(coords.split(',')[1]);
-      
+
         L.marker([lat, lng], {icon: greenIcon}).addTo(map).bindPopup(chapter);
-        
+
       }
     })
-    
+
     //handle columns
-    
+
     $("#chapter-list li").each(function(index) {
-      
+
       //console.log(index);
       //handle the categories that aren't chpaters -- hide
       if(index <= 2) {
-        
+
         $(this).addClass('hidden');
-      
+
       } else if(index <= 13) {
-        
+
         $(this).appendTo('#cc-0');
         $(this).removeClass('hidden');
-        
+
       } else if (index <= 24) {
-        
+
         $(this).appendTo('#cc-1');
         $(this).removeClass('hidden');
-         
+
       } else {
-        
+
         $(this).appendTo('#cc-2');
         $(this).removeClass('hidden');
-        
+
       }
-      
-      
+
+
     })
-    
+
   } /* close map */
-  
-}) 
+
+})

--- a/views/index.html
+++ b/views/index.html
@@ -60,7 +60,7 @@
         </div>
       </div>
 
-      <div class='video-embed'>
+      <div class='video-embed page-content'>
         <h2><%- video.headline %></h2>
         <%- video.description %>
       </div>


### PR DESCRIPTION
This fixes two things:
1. This stops the map from interpreting scrolling on the phone or moving the page with your thumb/finger on mobile as a zoom. This is better user experience when the map takes up a lot of the viewport. Users can still zoom with the zoom buttons.
2. This adds a container to the video so it doesn't go full-width on mobile and make it seem like there's no more content on the page/look inconsistent with the rest of the page margins.

cc @gjacobs86 
